### PR TITLE
Fixed youtube links markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # Introduction to git and its commands
 
-
 # Learning Git
 
 [Git LFS](https://github.com/git-lfs/git-lfs/wiki/Tutorial)
 
 # Youtube Links
-[https://youtu.be/8JJ101D3knE](Git Tutorial for Beginners: Learn Git in 1 Hour)
+
+[Git Tutorial for Beginners: Learn Git in 1 Hour](https://youtu.be/8JJ101D3knE)
 
 # Webiste Links
+
 [w3schools](https://www.w3schools.com/git/)
 
 [codecademy](https://www.codecademy.com/learn/learn-git)
@@ -16,5 +17,3 @@
 [learngitbranching](https://learngitbranching.js.org/)
 
 # Twitch Links
-
-


### PR DESCRIPTION
Issue #8 
Simple fix to display "Git tutorial for beginners" as a hyperlink to the YouTube video.